### PR TITLE
Code quality, logging, docs update, and test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ Pairs any Razer Nari headset variant with any Razer Nari dongle variant, bypassi
 
 **Supported Hardware:**
 
-- Razer Nari Ultimate **NOT TESTED** (likely works, needs verification)
+- Razer Nari Ultimate **TESTED** (confirmed working - thanks [@grumblefoot](https://github.com/grumblefoot) and [@rashidcultura](https://github.com/rashidcultura)!)
 - Razer Nari (Regular) **TESTED** (confirmed working)
 - Razer Nari Essential **NOT TESTED** (likely works, needs verification)
 
-**Note**: The pairing command was extracted from Razer's official utility which supports all Nari variants, and cross-model pairing has been confirmed working (Regular + Ultimate dongle). However, Ultimate and Essential models have not been directly tested yet. If you have these models, please test and report your results!
+**Tested Distros:**
+
+- Arch Linux
+- CachyOS (see [CachyOS notes](#cachyos--strict-pep-668-distros) below)
+
+**Note**: The pairing command was extracted from Razer's official utility which supports all Nari variants, and cross-model pairing has been confirmed working (Regular + Ultimate dongle). If you have a Nari Essential, please test and report your results!
 
 ## Quick Start
 
@@ -134,6 +139,19 @@ This tool was created through reverse engineering of the Razer Nari pairing prot
 - Try running the pairing tool again
 - Make sure headset was ON when commands were sent
 
+### CachyOS / strict PEP 668 distros
+
+Some distros (CachyOS, Fedora 38+, Ubuntu 23.04+) enforce [PEP 668](https://peps.python.org/pep-0668/) and block global pip installs. Use a virtual environment instead:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt    # use -v flag if install seems to hang
+sudo venv/bin/python3 razer_nari_pair.py
+```
+
+*(Thanks [@rashidcultura](https://github.com/rashidcultura) for testing on CachyOS!)*
+
 ### No audio
 
 - On Linux, check PulseAudio/PipeWire:
@@ -188,7 +206,7 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 **Priority areas:**
 
-- **Hardware testing** - Razer Nari Ultimate and Essential variants need testing
+- **Hardware testing** - Razer Nari Essential variant needs testing
 - **Bug reports** - Found an issue? Let us know!
 - **Code contributions** - Bug fixes, features, platform support
 - **Documentation** - Improvements, translations, troubleshooting tips

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/razer_nari_pair.py
+++ b/razer_nari_pair.py
@@ -118,12 +118,26 @@ class ColoredFormatter(logging.Formatter):
 
 def setup_logging(verbose: bool = False):
     level = logging.DEBUG if verbose else logging.INFO
-    handler = logging.StreamHandler()
-    handler.setFormatter(ColoredFormatter())
     logger.setLevel(level)
-    logger.addHandler(handler)
+    # Prevent messages from being propagated to the root logger and
+    # potentially logged twice if the root logger has handlers configured.
+    logger.propagate = False
 
+    # Avoid adding duplicate StreamHandlers if setup_logging is called
+    # multiple times (e.g. in tests or interactive sessions).
+    stream_handler_exists = any(
+        isinstance(h, logging.StreamHandler) for h in logger.handlers
+    )
 
+    if not stream_handler_exists:
+        handler = logging.StreamHandler()
+        handler.setFormatter(ColoredFormatter())
+        logger.addHandler(handler)
+    else:
+        # Ensure existing StreamHandlers use the expected formatter.
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                handler.setFormatter(ColoredFormatter())
 def print_header():
     print(f"{HEADER_COLOR}{BOLD}")
     print("=" * 70)

--- a/razer_nari_pair.py
+++ b/razer_nari_pair.py
@@ -110,7 +110,10 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         color = LEVEL_COLORS.get(record.levelno, "")
         tag = record.levelname
-        return f"{color}[{tag}]{RESET} {record.getMessage()}"
+        # Use the base Formatter to include exception information and any
+        # other standard formatting, then add color around the result.
+        base_message = super().format(record)
+        return f"{color}[{tag}]{RESET} {base_message}"
 
 
 def setup_logging(verbose: bool = False):

--- a/razer_nari_pair.py
+++ b/razer_nari_pair.py
@@ -6,7 +6,7 @@ Razer Nari Wireless Headset Pairing Tool - FINAL WORKING VERSION
 Successfully reverse-engineered pairing tool for Razer Nari headsets.
 Pairs any Nari variant headset with any Nari variant dongle.
 
-TESTED AND WORKING on Linux (Arch)
+TESTED AND WORKING on Linux (Arch) - Nari Regular and Nari Ultimate
 Cross-platform (Linux, Windows, macOS)
 Open source alternative to Razer's Windows-only utility
 
@@ -29,6 +29,9 @@ License: MIT
 Success Date: October 14, 2025
 """
 
+import argparse
+import logging
+import os
 import platform
 import sys
 import time
@@ -36,6 +39,12 @@ from typing import Optional
 
 import usb.core
 import usb.util
+
+# Custom log level for SUCCESS messages (between INFO and WARNING)
+SUCCESS = 25
+logging.addLevelName(SUCCESS, "SUCCESS")
+
+logger = logging.getLogger("razer_nari_pair")
 
 # ============================================================================
 # USB Device Constants
@@ -80,49 +89,45 @@ CMD_PAIR = bytes([0xFF, 0x19, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00])
 CMD_CANCEL_PAIR = bytes([0xFF, 0x19, 0x00, 0x49, 0x00, 0x00, 0x00, 0x00])
 
 # ============================================================================
-# Terminal Colors
+# Logging Setup
 # ============================================================================
 
+BOLD = "\033[1m"
+RESET = "\033[0m"
 
-class Colors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
+LEVEL_COLORS = {
+    logging.DEBUG: "\033[90m",     # Grey
+    logging.INFO: "\033[96m",      # Cyan
+    SUCCESS: "\033[92m",           # Green
+    logging.WARNING: "\033[93m",   # Yellow
+    logging.ERROR: "\033[91m",     # Red
+}
+
+HEADER_COLOR = "\033[95m"
 
 
-# ============================================================================
-# Helper Functions
-# ============================================================================
+class ColoredFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        color = LEVEL_COLORS.get(record.levelno, "")
+        tag = record.levelname
+        return f"{color}[{tag}]{RESET} {record.getMessage()}"
+
+
+def setup_logging(verbose: bool = False):
+    level = logging.DEBUG if verbose else logging.INFO
+    handler = logging.StreamHandler()
+    handler.setFormatter(ColoredFormatter())
+    logger.setLevel(level)
+    logger.addHandler(handler)
 
 
 def print_header():
-    print(f"{Colors.HEADER}{Colors.BOLD}")
+    print(f"{HEADER_COLOR}{BOLD}")
     print("=" * 70)
     print("Razer Nari Wireless Pairing Tool")
     print("Community Open-Source Implementation - FINAL VERSION")
     print("=" * 70)
-    print(f"{Colors.ENDC}")
-
-
-def print_info(msg: str):
-    print(f"{Colors.OKCYAN}[INFO]{Colors.ENDC} {msg}")
-
-
-def print_success(msg: str):
-    print(f"{Colors.OKGREEN}[SUCCESS]{Colors.ENDC} {msg}")
-
-
-def print_warning(msg: str):
-    print(f"{Colors.WARNING}[WARNING]{Colors.ENDC} {msg}")
-
-
-def print_error(msg: str):
-    print(f"{Colors.FAIL}[ERROR]{Colors.ENDC} {msg}")
+    print(RESET)
 
 
 # ============================================================================
@@ -133,9 +138,10 @@ def print_error(msg: str):
 def find_device_by_pids(pid_dict: dict) -> Optional[usb.core.Device]:
     """Find first device matching any of the given PIDs"""
     for pid, name in pid_dict.items():
+        logger.debug("Looking for %s (VID=%04X, PID=%04X)", name, RAZER_VID, pid)
         dev = usb.core.find(idVendor=RAZER_VID, idProduct=pid)
         if dev:
-            print_success(f"Found: {name} ({RAZER_VID:04X}:{pid:04X})")
+            logger.log(SUCCESS, f"Found: {name} ({RAZER_VID:04X}:{pid:04X})")
             return dev
     return None
 
@@ -145,13 +151,14 @@ def claim_interface(dev: usb.core.Device, interface: int) -> bool:
     try:
         if platform.system() == "Linux":
             if dev.is_kernel_driver_active(interface):
+                logger.debug("Detaching kernel driver from interface %d", interface)
                 dev.detach_kernel_driver(interface)
 
         usb.util.claim_interface(dev, interface)
-        print_info(f"Claimed interface {interface}")
+        logger.info("Claimed interface %d", interface)
         return True
     except Exception as e:
-        print_error(f"Failed to claim interface {interface}: {e}")
+        logger.error("Failed to claim interface %d: %s", interface, e)
         return False
 
 
@@ -162,9 +169,9 @@ def release_interface(dev: usb.core.Device, interface: int):
         if platform.system() == "Linux":
             try:
                 dev.attach_kernel_driver(interface)
-            except:
+            except Exception:
                 pass
-    except:
+    except Exception:
         pass
 
 
@@ -187,13 +194,19 @@ def send_hid_command(dev: usb.core.Device, interface: int, command: bytes) -> bo
         wValue = 0x0300  # Feature Report, ID 0
         wIndex = interface  # Interface number
 
+        logger.debug(
+            "ctrl_transfer: bmRequestType=0x%02X bRequest=0x%02X "
+            "wValue=0x%04X wIndex=%d data=%s",
+            bmRequestType, bRequest, wValue, wIndex, command.hex(" "),
+        )
         result = dev.ctrl_transfer(
             bmRequestType, bRequest, wValue, wIndex, command, timeout=1000
         )
+        logger.debug("ctrl_transfer returned %d (expected %d)", result, len(command))
 
         return result == len(command)
     except Exception as e:
-        print_error(f"Failed to send command: {e}")
+        logger.error("Failed to send command: %s", e)
         return False
 
 
@@ -216,41 +229,39 @@ def pair_devices() -> bool:
     print()
 
     # Check for root permissions
-    import os
-
     if platform.system() == "Linux" and os.geteuid() != 0:
-        print_error("This tool requires root/sudo privileges on Linux")
-        print_info("Please run: sudo python3 razer_nari_pair_FINAL.py")
+        logger.error("This tool requires root/sudo privileges on Linux")
+        logger.info("Please run: sudo python3 razer_nari_pair.py")
         return False
 
-    print(f"{Colors.BOLD}Step 1: Checking Hardware{Colors.ENDC}")
+    print(f"{BOLD}Step 1: Checking Hardware{RESET}")
     print()
 
     # Find dongle
-    print_info("Searching for dongle...")
+    logger.info("Searching for dongle...")
     dongle = find_device_by_pids(DONGLE_PIDS)
     if not dongle:
-        print_error("No Razer Nari dongle found!")
-        print_info("Please plug in the USB dongle and try again")
+        logger.error("No Razer Nari dongle found!")
+        logger.info("Please plug in the USB dongle and try again")
         return False
 
     # Find headset (must be USB-connected via charging cable)
-    print_info("Searching for headset (via USB charging cable)...")
+    logger.info("Searching for headset (via USB charging cable)...")
     headset = find_device_by_pids(HEADSET_PIDS)
     if not headset:
-        print_error("No Razer Nari headset found via USB!")
+        logger.error("No Razer Nari headset found via USB!")
         print()
-        print_warning(
+        logger.warning(
             "The headset MUST be connected via USB charging cable during pairing"
         )
-        print_info("Steps:")
-        print_info("  1. Connect headset to PC using USB charging cable")
-        print_info("  2. Turn ON the headset (press power button)")
-        print_info("  3. Run this tool again")
+        logger.info("Steps:")
+        logger.info("  1. Connect headset to PC using USB charging cable")
+        logger.info("  2. Turn ON the headset (press power button)")
+        logger.info("  3. Run this tool again")
         return False
 
     print()
-    print(f"{Colors.BOLD}Step 2: Preparing Devices{Colors.ENDC}")
+    print(f"{BOLD}Step 2: Preparing Devices{RESET}")
     print()
 
     # Claim dongle interface
@@ -264,53 +275,53 @@ def pair_devices() -> bool:
 
     try:
         print()
-        print(f"{Colors.BOLD}Step 3: Sending Pairing Commands{Colors.ENDC}")
+        print(f"{BOLD}Step 3: Sending Pairing Commands{RESET}")
         print()
-        print_info("Command: " + CMD_PAIR.hex(" ").upper())
+        logger.info("Command: %s", CMD_PAIR.hex(" ").upper())
         print()
 
         # Send pairing command to DONGLE
-        print_info("Sending pairing command to dongle...")
+        logger.info("Sending pairing command to dongle...")
         if send_hid_command(dongle, DONGLE_HID_INTERFACE, CMD_PAIR):
-            print_success("Dongle command sent successfully")
+            logger.log(SUCCESS, "Dongle command sent successfully")
         else:
-            print_error("Failed to send command to dongle")
+            logger.error("Failed to send command to dongle")
             return False
 
         time.sleep(1)
 
         # Send pairing command to HEADSET
-        print_info("Sending pairing command to headset...")
+        logger.info("Sending pairing command to headset...")
         if send_hid_command(headset, HEADSET_HID_INTERFACE, CMD_PAIR):
-            print_success("Headset command sent successfully")
+            logger.log(SUCCESS, "Headset command sent successfully")
         else:
-            print_error("Failed to send command to headset")
+            logger.error("Failed to send command to headset")
             return False
 
         print()
         print(
-            f"{Colors.OKGREEN}{Colors.BOLD}✓ Pairing commands sent to both devices!{Colors.ENDC}"
+            f"\033[92m{BOLD}✓ Pairing commands sent to both devices!{RESET}"
         )
         print()
-        print_info("Waiting 5 seconds for devices to exchange pairing data...")
+        logger.info("Waiting 5 seconds for devices to exchange pairing data...")
         time.sleep(5)
 
         print()
-        print(f"{Colors.BOLD}Step 4: Testing Wireless Connection{Colors.ENDC}")
+        print(f"{BOLD}Step 4: Testing Wireless Connection{RESET}")
         print()
-        print(f"{Colors.OKGREEN}Next steps:{Colors.ENDC}")
+        print(f"\033[92mNext steps:{RESET}")
         print("  1. Disconnect the headset USB cable")
         print("  2. Turn the headset OFF (hold power button)")
         print("  3. Turn the headset ON")
         print("  4. The headset should connect wirelessly to the dongle!")
         print()
-        print(f"{Colors.OKGREEN}Expected result:{Colors.ENDC}")
+        print(f"\033[92mExpected result:{RESET}")
         print("  • Headset LED turns solid blue (connected)")
         print("  • You hear a connection sound in the headset")
         print("  • Audio works wirelessly!")
         print()
         print(
-            f"{Colors.BOLD}The pairing is now PERMANENT - devices remember each other!{Colors.ENDC}"
+            f"{BOLD}The pairing is now PERMANENT - devices remember each other!{RESET}"
         )
         print()
 
@@ -320,7 +331,7 @@ def pair_devices() -> bool:
         # Release interfaces
         release_interface(headset, HEADSET_HID_INTERFACE)
         release_interface(dongle, DONGLE_HID_INTERFACE)
-        print_info("Released all interfaces")
+        logger.info("Released all interfaces")
 
 
 # ============================================================================
@@ -328,17 +339,30 @@ def pair_devices() -> bool:
 # ============================================================================
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Razer Nari Wireless Headset Pairing Tool"
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable debug output"
+    )
+    return parser.parse_args()
+
+
 def main():
     """Main function"""
+    args = parse_args()
+    setup_logging(verbose=args.verbose)
+
     try:
         success = pair_devices()
 
         print()
         if success:
-            print(f"{Colors.OKGREEN}{Colors.BOLD}=" * 70)
+            print(f"\033[92m{BOLD}=" * 70)
             print("PAIRING COMPLETE! 🎉")
             print("=" * 70)
-            print(f"{Colors.ENDC}")
+            print(RESET)
             print()
             print("Your headset is now paired with the dongle!")
             print("From now on, just:")
@@ -349,20 +373,17 @@ def main():
             sys.exit(0)
         else:
             print(
-                f"{Colors.FAIL}Pairing failed. Please check the instructions above.{Colors.ENDC}"
+                f"\033[91mPairing failed. Please check the instructions above.{RESET}"
             )
             sys.exit(1)
 
     except KeyboardInterrupt:
         print()
-        print_info("Interrupted by user")
+        logger.info("Interrupted by user")
         sys.exit(0)
-    except Exception as e:
+    except Exception:
         print()
-        print_error(f"Unexpected error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception("Unexpected error")
         sys.exit(1)
 
 

--- a/razer_nari_pair.py
+++ b/razer_nari_pair.py
@@ -158,7 +158,7 @@ def find_device_by_pids(pid_dict: dict) -> Optional[usb.core.Device]:
         logger.debug("Looking for %s (VID=%04X, PID=%04X)", name, RAZER_VID, pid)
         dev = usb.core.find(idVendor=RAZER_VID, idProduct=pid)
         if dev:
-            logger.log(SUCCESS, f"Found: {name} ({RAZER_VID:04X}:{pid:04X})")
+            logger.log(SUCCESS, "Found: %s (%04X:%04X)", name, RAZER_VID, pid)
             return dev
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for razer_nari_pair tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import razer_nari_pair
+
+
+@pytest.fixture(autouse=True)
+def _reset_logger():
+    """Ensure logger is set up and cleaned between tests."""
+    razer_nari_pair.setup_logging(verbose=False)
+    yield
+    razer_nari_pair.logger.handlers.clear()
+
+
+@pytest.fixture()
+def mock_usb_device():
+    """Factory that creates a mock usb.core.Device."""
+
+    def _make(**overrides):
+        dev = MagicMock()
+        dev.is_kernel_driver_active.return_value = False
+        dev.ctrl_transfer.return_value = 8  # matches CMD_PAIR length
+        for attr, val in overrides.items():
+            setattr(dev, attr, val)
+        return dev
+
+    return _make

--- a/tests/test_razer_nari_pair.py
+++ b/tests/test_razer_nari_pair.py
@@ -1,0 +1,480 @@
+"""Tests for razer_nari_pair — unit and integration."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import razer_nari_pair
+from razer_nari_pair import (
+    CMD_PAIR,
+    DONGLE_HID_INTERFACE,
+    DONGLE_PIDS,
+    HEADSET_HID_INTERFACE,
+    HEADSET_PIDS,
+    RAZER_VID,
+    SUCCESS,
+    ColoredFormatter,
+    claim_interface,
+    find_device_by_pids,
+    pair_devices,
+    parse_args,
+    release_interface,
+    send_hid_command,
+    setup_logging,
+)
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+
+class TestConstants:
+    def test_razer_vid(self):
+        assert RAZER_VID == 0x1532
+
+    def test_dongle_pids_are_correct(self):
+        assert 0x051A in DONGLE_PIDS  # Ultimate
+        assert 0x051C in DONGLE_PIDS  # Regular
+        assert 0x051E in DONGLE_PIDS  # Essential
+
+    def test_headset_pids_are_correct(self):
+        assert 0x051B in HEADSET_PIDS  # Ultimate
+        assert 0x051D in HEADSET_PIDS  # Regular
+        assert 0x051F in HEADSET_PIDS  # Essential
+
+    def test_dongle_headset_pids_are_paired(self):
+        """Each dongle PID should be exactly 1 less than its headset PID."""
+        for dongle_pid in DONGLE_PIDS:
+            assert dongle_pid + 1 in HEADSET_PIDS
+
+    def test_pair_command_format(self):
+        assert CMD_PAIR == bytes([0xFF, 0x19, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00])
+        assert len(CMD_PAIR) == 8
+
+    def test_interfaces(self):
+        assert DONGLE_HID_INTERFACE == 5
+        assert HEADSET_HID_INTERFACE == 0
+
+    def test_success_level(self):
+        assert SUCCESS == 25
+
+
+# ============================================================================
+# Logging
+# ============================================================================
+
+
+class TestLogging:
+    def test_setup_logging_default_level(self):
+        razer_nari_pair.logger.handlers.clear()
+        setup_logging(verbose=False)
+        assert razer_nari_pair.logger.level == 20  # INFO
+
+    def test_setup_logging_verbose(self):
+        razer_nari_pair.logger.handlers.clear()
+        setup_logging(verbose=True)
+        assert razer_nari_pair.logger.level == 10  # DEBUG
+
+    def test_setup_logging_no_duplicate_handlers(self):
+        razer_nari_pair.logger.handlers.clear()
+        setup_logging()
+        setup_logging()
+        handler_count = len(razer_nari_pair.logger.handlers)
+        assert handler_count == 1
+
+    def test_colored_formatter_info(self):
+        import logging
+
+        fmt = ColoredFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        output = fmt.format(record)
+        assert "[INFO]" in output
+        assert "hello" in output
+
+    def test_colored_formatter_error(self):
+        import logging
+
+        fmt = ColoredFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="bad", args=(), exc_info=None,
+        )
+        output = fmt.format(record)
+        assert "[ERROR]" in output
+
+    def test_colored_formatter_success(self):
+        import logging
+
+        fmt = ColoredFormatter()
+        record = logging.LogRecord(
+            name="test", level=SUCCESS, pathname="", lineno=0,
+            msg="done", args=(), exc_info=None,
+        )
+        output = fmt.format(record)
+        assert "[SUCCESS]" in output
+
+
+# ============================================================================
+# find_device_by_pids
+# ============================================================================
+
+
+class TestFindDeviceByPids:
+    @patch("razer_nari_pair.usb.core.find")
+    def test_returns_device_when_found(self, mock_find, mock_usb_device):
+        dev = mock_usb_device()
+        mock_find.return_value = dev
+
+        result = find_device_by_pids({0x051C: "Razer Nari"})
+
+        assert result is dev
+        mock_find.assert_called_once_with(idVendor=RAZER_VID, idProduct=0x051C)
+
+    @patch("razer_nari_pair.usb.core.find")
+    def test_returns_none_when_not_found(self, mock_find):
+        mock_find.return_value = None
+
+        result = find_device_by_pids(DONGLE_PIDS)
+
+        assert result is None
+        assert mock_find.call_count == len(DONGLE_PIDS)
+
+    @patch("razer_nari_pair.usb.core.find")
+    def test_returns_first_match(self, mock_find, mock_usb_device):
+        dev = mock_usb_device()
+        # First PID not found, second PID found
+        mock_find.side_effect = [None, dev]
+
+        pids = {0x051A: "Ultimate", 0x051C: "Regular"}
+        result = find_device_by_pids(pids)
+
+        assert result is dev
+        assert mock_find.call_count == 2
+
+    @patch("razer_nari_pair.usb.core.find")
+    def test_empty_pid_dict(self, mock_find):
+        result = find_device_by_pids({})
+        assert result is None
+        mock_find.assert_not_called()
+
+
+# ============================================================================
+# claim_interface
+# ============================================================================
+
+
+class TestClaimInterface:
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    def test_claims_successfully_linux(self, mock_claim, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+        dev.is_kernel_driver_active.return_value = False
+
+        assert claim_interface(dev, 5) is True
+        mock_claim.assert_called_once_with(dev, 5)
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    def test_detaches_kernel_driver_if_active(self, mock_claim, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+        dev.is_kernel_driver_active.return_value = True
+
+        assert claim_interface(dev, 5) is True
+        dev.detach_kernel_driver.assert_called_once_with(5)
+
+    @patch("razer_nari_pair.platform.system", return_value="Windows")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    def test_skips_kernel_driver_on_non_linux(self, mock_claim, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+
+        assert claim_interface(dev, 5) is True
+        dev.is_kernel_driver_active.assert_not_called()
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.claim_interface", side_effect=Exception("busy"))
+    def test_returns_false_on_error(self, mock_claim, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+        dev.is_kernel_driver_active.return_value = False
+
+        assert claim_interface(dev, 5) is False
+
+
+# ============================================================================
+# release_interface
+# ============================================================================
+
+
+class TestReleaseInterface:
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.release_interface")
+    def test_releases_and_reattaches_driver(self, mock_release, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+
+        release_interface(dev, 5)
+
+        mock_release.assert_called_once_with(dev, 5)
+        dev.attach_kernel_driver.assert_called_once_with(5)
+
+    @patch("razer_nari_pair.platform.system", return_value="Windows")
+    @patch("razer_nari_pair.usb.util.release_interface")
+    def test_skips_reattach_on_non_linux(self, mock_release, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+
+        release_interface(dev, 5)
+
+        mock_release.assert_called_once_with(dev, 5)
+        dev.attach_kernel_driver.assert_not_called()
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.release_interface", side_effect=Exception("fail"))
+    def test_does_not_raise_on_error(self, mock_release, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+        # Should not raise
+        release_interface(dev, 5)
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.usb.util.release_interface")
+    def test_does_not_raise_if_reattach_fails(self, mock_release, _mock_sys, mock_usb_device):
+        dev = mock_usb_device()
+        dev.attach_kernel_driver.side_effect = Exception("no driver")
+
+        release_interface(dev, 5)  # should not raise
+
+
+# ============================================================================
+# send_hid_command
+# ============================================================================
+
+
+class TestSendHidCommand:
+    def test_successful_transfer(self, mock_usb_device):
+        dev = mock_usb_device()
+        dev.ctrl_transfer.return_value = 8
+
+        assert send_hid_command(dev, 5, CMD_PAIR) is True
+        dev.ctrl_transfer.assert_called_once_with(
+            0x21, 0x09, 0x0300, 5, CMD_PAIR, timeout=1000,
+        )
+
+    def test_partial_transfer_returns_false(self, mock_usb_device):
+        dev = mock_usb_device()
+        dev.ctrl_transfer.return_value = 4  # only 4 of 8 bytes sent
+
+        assert send_hid_command(dev, 5, CMD_PAIR) is False
+
+    def test_transfer_exception_returns_false(self, mock_usb_device):
+        dev = mock_usb_device()
+        dev.ctrl_transfer.side_effect = Exception("USB timeout")
+
+        assert send_hid_command(dev, 5, CMD_PAIR) is False
+
+    def test_uses_correct_hid_constants(self, mock_usb_device):
+        dev = mock_usb_device()
+        dev.ctrl_transfer.return_value = 8
+
+        send_hid_command(dev, 0, CMD_PAIR)
+
+        args = dev.ctrl_transfer.call_args
+        assert args[0][0] == 0x21  # bmRequestType: Host-to-device, Class, Interface
+        assert args[0][1] == 0x09  # bRequest: SET_REPORT
+        assert args[0][2] == 0x0300  # wValue: Feature Report, ID 0
+        assert args[0][3] == 0  # wIndex: interface number
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+
+class TestParseArgs:
+    def test_default_args(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py"])
+        args = parse_args()
+        assert args.verbose is False
+
+    def test_verbose_short(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py", "-v"])
+        args = parse_args()
+        assert args.verbose is True
+
+    def test_verbose_long(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py", "--verbose"])
+        args = parse_args()
+        assert args.verbose is True
+
+
+# ============================================================================
+# pair_devices (integration)
+# ============================================================================
+
+
+class TestPairDevicesIntegration:
+    """End-to-end tests of pair_devices() with mocked USB layer."""
+
+    @patch("razer_nari_pair.time.sleep")
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.util.release_interface")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    @patch("razer_nari_pair.usb.core.find")
+    def test_successful_pairing(
+        self, mock_find, mock_claim, mock_release, mock_geteuid,
+        _mock_sys, mock_sleep, mock_usb_device,
+    ):
+        dongle = mock_usb_device()
+        headset = mock_usb_device()
+
+        # First 3 calls for dongle PIDs (first matches), next 3 for headset PIDs (first matches)
+        mock_find.side_effect = [dongle, headset]
+
+        result = pair_devices()
+
+        assert result is True
+        # Both devices got the pair command
+        dongle.ctrl_transfer.assert_called_once()
+        headset.ctrl_transfer.assert_called_once()
+        # Interfaces were released
+        assert mock_release.call_count == 2
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=1000)
+    def test_fails_without_root(self, mock_geteuid, _mock_sys):
+        result = pair_devices()
+        assert result is False
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.core.find", return_value=None)
+    def test_fails_no_dongle(self, mock_find, mock_geteuid, _mock_sys):
+        result = pair_devices()
+        assert result is False
+
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.core.find")
+    def test_fails_no_headset(self, mock_find, mock_geteuid, _mock_sys, mock_usb_device):
+        dongle = mock_usb_device()
+        # Dongle found on first call, headset not found (3 None for each headset PID)
+        mock_find.side_effect = [dongle, None, None, None]
+
+        result = pair_devices()
+        assert result is False
+
+    @patch("razer_nari_pair.time.sleep")
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.util.release_interface")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    @patch("razer_nari_pair.usb.core.find")
+    def test_fails_dongle_command_error(
+        self, mock_find, mock_claim, mock_release, mock_geteuid,
+        _mock_sys, mock_sleep, mock_usb_device,
+    ):
+        dongle = mock_usb_device()
+        headset = mock_usb_device()
+        dongle.ctrl_transfer.side_effect = Exception("USB error")
+        mock_find.side_effect = [dongle, headset]
+
+        result = pair_devices()
+
+        assert result is False
+        # Interfaces still released in finally block
+        assert mock_release.call_count == 2
+
+    @patch("razer_nari_pair.time.sleep")
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.util.release_interface")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    @patch("razer_nari_pair.usb.core.find")
+    def test_fails_headset_command_error(
+        self, mock_find, mock_claim, mock_release, mock_geteuid,
+        _mock_sys, mock_sleep, mock_usb_device,
+    ):
+        dongle = mock_usb_device()
+        headset = mock_usb_device()
+        headset.ctrl_transfer.side_effect = Exception("USB error")
+        mock_find.side_effect = [dongle, headset]
+
+        result = pair_devices()
+
+        assert result is False
+        assert mock_release.call_count == 2
+
+    @patch("razer_nari_pair.time.sleep")
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.util.release_interface")
+    @patch("razer_nari_pair.usb.util.claim_interface", side_effect=Exception("busy"))
+    @patch("razer_nari_pair.usb.core.find")
+    def test_fails_claim_dongle_interface(
+        self, mock_find, mock_claim, mock_release, mock_geteuid,
+        _mock_sys, mock_sleep, mock_usb_device,
+    ):
+        dongle = mock_usb_device()
+        headset = mock_usb_device()
+        mock_find.side_effect = [dongle, headset]
+
+        result = pair_devices()
+        assert result is False
+
+    @patch("razer_nari_pair.time.sleep")
+    @patch("razer_nari_pair.platform.system", return_value="Linux")
+    @patch("razer_nari_pair.os.geteuid", return_value=0)
+    @patch("razer_nari_pair.usb.util.release_interface")
+    @patch("razer_nari_pair.usb.util.claim_interface")
+    @patch("razer_nari_pair.usb.core.find")
+    def test_claim_headset_fails_releases_dongle(
+        self, mock_find, mock_claim, mock_release, mock_geteuid,
+        _mock_sys, mock_sleep, mock_usb_device,
+    ):
+        dongle = mock_usb_device()
+        headset = mock_usb_device()
+        mock_find.side_effect = [dongle, headset]
+        # First claim (dongle) succeeds, second (headset) fails
+        mock_claim.side_effect = [None, Exception("busy")]
+
+        result = pair_devices()
+
+        assert result is False
+        # Dongle interface released after headset claim failure
+        mock_release.assert_called()
+
+
+# ============================================================================
+# main (integration)
+# ============================================================================
+
+
+class TestMainIntegration:
+    @patch("razer_nari_pair.pair_devices", return_value=True)
+    def test_exits_0_on_success(self, mock_pair, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py"])
+        with pytest.raises(SystemExit) as exc_info:
+            razer_nari_pair.main()
+        assert exc_info.value.code == 0
+
+    @patch("razer_nari_pair.pair_devices", return_value=False)
+    def test_exits_1_on_failure(self, mock_pair, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py"])
+        with pytest.raises(SystemExit) as exc_info:
+            razer_nari_pair.main()
+        assert exc_info.value.code == 1
+
+    @patch("razer_nari_pair.pair_devices", side_effect=KeyboardInterrupt)
+    def test_exits_0_on_keyboard_interrupt(self, mock_pair, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py"])
+        with pytest.raises(SystemExit) as exc_info:
+            razer_nari_pair.main()
+        assert exc_info.value.code == 0
+
+    @patch("razer_nari_pair.pair_devices", side_effect=RuntimeError("boom"))
+    def test_exits_1_on_unexpected_error(self, mock_pair, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["razer_nari_pair.py"])
+        with pytest.raises(SystemExit) as exc_info:
+            razer_nari_pair.main()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

- **Logging overhaul** — Replaced ad-hoc `print_*` helpers with Python `logging` module using a custom `ColoredFormatter` that preserves the same colored terminal output. Added a custom `SUCCESS` log level (25). Added `-v`/`--verbose` CLI flag for debug output (USB transfer details, device discovery, kernel driver events).
- **Code quality fixes** — Bare `except:` → `except Exception:`, moved inline imports (`os`, `traceback`) to module level, string concatenation → f-string, fixed wrong script name in error message (`razer_nari_pair_FINAL.py` → `razer_nari_pair.py`).
- **Documentation updates** — Razer Nari Ultimate marked as **TESTED** (thanks @grumblefoot and @rashidcultura!). Added tested distros section (Arch Linux, CachyOS). Added troubleshooting section for PEP 668 distros with venv instructions. Updated contributing section to reflect only Essential still needs testing.
- **Test suite** — Added 44 pytest tests (unit + integration) covering all functions with mocked USB layer. Tests cover device discovery, interface claiming/releasing, HID commands, pairing flow (success + all failure paths), CLI argument parsing, logging setup, and `main()` exit codes.

## Changes

| File | What changed |
|------|-------------|
| `razer_nari_pair.py` | Logging system, code fixes, argparse |
| `README.md` | Hardware status, tested distros, CachyOS troubleshooting |
| `tests/test_razer_nari_pair.py` | 44 tests (unit + integration) |
| `tests/conftest.py` | Shared fixtures (mock USB device, logger reset) |
| `tests/__init__.py` | Package init |
| `pytest.ini` | Test runner config |

## Test plan

- [x] `python3 -m py_compile razer_nari_pair.py` — no syntax errors
- [x] `python3 -m pytest tests/ -v` — 44/44 passed
- [x] `python3 razer_nari_pair.py --help` — shows `-v` flag
- [ ] Manual pairing test with hardware (Nari Regular or Ultimate)